### PR TITLE
🧹 fix module path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module tailscale.com/client/tailscale/v2
+module tailscale.com/client/tailscale-client-go-v2
 
 go 1.22.0
 


### PR DESCRIPTION
Today, if you try to use this new repository, you would get this:
```
➜  tailscale git:(afiune/tailscale) ✗ go mod tidy
go: finding module for package github.com/tailscale/tailscale-client-go-v2
go: go.mondoo.com/cnquery/v11/providers/tailscale/connection imports
	github.com/tailscale/tailscale-client-go-v2: no matching versions for query "latest"
```

This should fix that problem.