### PR TITLE
.github: add GitHub actions to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Add GitHub actions to our dependabot config.

Fixes https://github.com/tailscale/tailscale-client-go-v2/issues/15