### PR TITLE
devices: support querying all fields for individual device

### DIFF
--- a/devices.go
+++ b/devices.go
@@ -107,13 +107,31 @@ type DevicePostureAttributeRequest struct {
 	Comment string `json:"comment"`
 }
 
-// Get gets the [Device] identified by deviceID.
+// GetWithAllFields gets the [Device] identified by `deviceID`.
+// All fields will be populated.
+//
+// Using the device `NodeID` is preferred, but its numeric `ID` value can also be used.
+func (dr *DevicesResource) GetWithAllFields(ctx context.Context, deviceID string) (*Device, error) {
+	return dr.get(ctx, deviceID, true)
+}
+
+// Get gets the [Device] identified by `deviceID`.
 //
 // Using the device `NodeID` is preferred, but its numeric `ID` value can also be used.
 func (dr *DevicesResource) Get(ctx context.Context, deviceID string) (*Device, error) {
+	return dr.get(ctx, deviceID, false)
+}
+
+func (dr *DevicesResource) get(ctx context.Context, deviceID string, allFields bool) (*Device, error) {
 	req, err := dr.buildRequest(ctx, http.MethodGet, dr.buildURL("device", deviceID))
 	if err != nil {
 		return nil, err
+	}
+
+	if allFields {
+		q := req.URL.Query()
+		q.Set("fields", "all")
+		req.URL.RawQuery = q.Encode()
 	}
 
 	return body[Device](dr, req)
@@ -156,13 +174,13 @@ func (dr *DevicesResource) List(ctx context.Context) ([]Device, error) {
 	return dr.list(ctx, false)
 }
 
-func (dr *DevicesResource) list(ctx context.Context, all bool) ([]Device, error) {
+func (dr *DevicesResource) list(ctx context.Context, allFields bool) ([]Device, error) {
 	req, err := dr.buildRequest(ctx, http.MethodGet, dr.buildTailnetURL("devices"))
 	if err != nil {
 		return nil, err
 	}
 
-	if all {
+	if allFields {
 		q := req.URL.Query()
 		q.Set("fields", "all")
 		req.URL.RawQuery = q.Encode()

--- a/devices_test.go
+++ b/devices_test.go
@@ -94,19 +94,21 @@ func TestClient_Devices_Get(t *testing.T) {
 	server.ResponseCode = http.StatusOK
 	server.ResponseBody = expectedDevice
 
-	t.Run("using legacy id", func(t *testing.T) {
+	t.Run("using legacy id with default fields", func(t *testing.T) {
 		actualDevice, err := client.Devices().Get(context.Background(), "12345")
 		assert.NoError(t, err)
 		assert.Equal(t, http.MethodGet, server.Method)
 		assert.Equal(t, "/api/v2/device/12345", server.Path)
+		assert.Empty(t, server.Query.Get("fields"))
 		assert.EqualValues(t, expectedDevice, actualDevice)
 	})
 
-	t.Run("using preferred nodeId", func(t *testing.T) {
-		actualDevice, err := client.Devices().Get(context.Background(), "nTESTJ31")
+	t.Run("using preferred nodeId with all fields", func(t *testing.T) {
+		actualDevice, err := client.Devices().GetWithAllFields(context.Background(), "nTESTJ31")
 		assert.NoError(t, err)
 		assert.Equal(t, http.MethodGet, server.Method)
 		assert.Equal(t, "/api/v2/device/nTESTJ31", server.Path)
+		assert.Equal(t, "all", server.Query.Get("fields"))
 		assert.EqualValues(t, expectedDevice, actualDevice)
 	})
 }


### PR DESCRIPTION
Add 'ListWithAllFields' to 'DevicesResource' to allow getting a device with all of its fields populated.

Updates tailscale/corp#23564