### PR TITLE
keys: Added key type to the response payload

### DIFF
--- a/keys.go
+++ b/keys.go
@@ -48,6 +48,7 @@ type createOAuthClientWithKeyTypeRequest struct {
 // Key describes an authentication key within the tailnet.
 type Key struct {
 	ID           string          `json:"id"`
+	KeyType      string          `json:"keyType"`
 	Key          string          `json:"key"`
 	Description  string          `json:"description"`
 	Created      time.Time       `json:"created"`

--- a/keys_test.go
+++ b/keys_test.go
@@ -27,6 +27,7 @@ func TestClient_CreateAuthKey(t *testing.T) {
 
 	expected := &Key{
 		ID:           "test",
+		KeyType:      "auth",
 		Key:          "thisisatestkey",
 		Created:      time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
 		Expires:      time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
@@ -65,6 +66,7 @@ func TestClient_CreateAuthKeyWithExpirySeconds(t *testing.T) {
 
 	expected := &Key{
 		ID:           "test",
+		KeyType:      "auth",
 		Key:          "thisisatestkey",
 		Created:      time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
 		Expires:      time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
@@ -104,6 +106,7 @@ func TestClient_CreateAuthKeyWithDescription(t *testing.T) {
 
 	expected := &Key{
 		ID:           "test",
+		KeyType:      "auth",
 		Key:          "thisisatestkey",
 		Created:      time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
 		Expires:      time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
@@ -137,6 +140,7 @@ func TestClient_CreateOAuthClient(t *testing.T) {
 
 	expected := &Key{
 		ID:          "test",
+		KeyType:     "client",
 		Key:         "thisisatestclient",
 		Created:     time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
 		Expires:     time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
@@ -178,6 +182,7 @@ func TestClient_GetKey(t *testing.T) {
 
 	expected := &Key{
 		ID:           "test",
+		KeyType:      "auth",
 		Created:      time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
 		Expires:      time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
 		Capabilities: capabilities,


### PR DESCRIPTION
Added the key type to the response so it aligns with the latest API changes and can be used to prevent non-auth key imports from the TF provider.

Updates tailscale/tailscale#9632