### PR TITLE
policyfile: support passing ETags with and without double quotes when setting ACL 

### DIFF
--- a/policyfile.go
+++ b/policyfile.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 )
 
@@ -198,7 +199,7 @@ func (pr *PolicyFileResource) Raw(ctx context.Context) (*RawACL, error) {
 func (pr *PolicyFileResource) Set(ctx context.Context, acl any, etag string) error {
 	headers := make(map[string]string)
 	if etag != "" {
-		headers["If-Match"] = fmt.Sprintf("%q", etag)
+		headers["If-Match"] = fmt.Sprintf("%q", strings.Trim(etag, `"`))
 	}
 
 	reqOpts := []requestOption{
@@ -226,7 +227,7 @@ func (pr *PolicyFileResource) Set(ctx context.Context, acl any, etag string) err
 func (pr *PolicyFileResource) SetAndGet(ctx context.Context, acl ACL, etag string) (*ACL, error) {
 	headers := make(map[string]string)
 	if etag != "" {
-		headers["If-Match"] = fmt.Sprintf("%q", etag)
+		headers["If-Match"] = fmt.Sprintf("%q", strings.Trim(etag, `"`))
 	}
 
 	reqOpts := []requestOption{


### PR DESCRIPTION
This changes the `Set` and `SetAndGet` for ACLs to support ETag parameters that are passed as strings enclosed in escaped double quotes, e.g. `"xyzzy"`.

The default ETag format as per the spec includes the double quotes and the API returns ETags in double quotes, however the client currently rejects ETag parameters that come in double-quotes.

Changing this streamlines the experience of users who want to rely on the ETag in scenarios where they read, modify and write an ACL with the client and want to ensure the ACL hasn’t been modified between reading and writing.


Fixes #27