### PR TITLE
v2/logging: add support for network flow logs API

### DIFF
--- a/logging_test.go
+++ b/logging_test.go
@@ -6,8 +6,10 @@ package tailscale
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -129,3 +131,80 @@ func TestClient_ValidateAWSTrustPolicy(t *testing.T) {
 	assert.NoError(t, err)
 	assert.EqualValues(t, gotRequest, map[string]string{"roleArn": roleARN})
 }
+
+func TestClient_GetNetworkFlowLogs(t *testing.T) {
+	t.Parallel()
+
+	client, server := NewTestHarness(t)
+	server.ResponseCode = http.StatusOK
+
+	now := time.Now().UTC().Truncate(time.Second)
+	expectedLogs := []NetworkFlowLog{
+		{
+			Logged: now,
+			NodeID: "node1",
+			Start:  now.Add(-5 * time.Minute),
+			End:    now,
+			VirtualTraffic: []TrafficStats{
+				{Proto: 6, Src: "10.0.0.1:80", Dst: "10.0.0.2:1234", TxPkts: 10, TxBytes: 1000},
+			},
+		},
+		{
+			Logged: now.Add(1 * time.Second),
+			NodeID: "node2",
+			Start:  now.Add(-4 * time.Minute),
+			End:    now.Add(1 * time.Second),
+			PhysicalTraffic: []TrafficStats{
+				{Proto: 17, Src: "192.168.1.1:53", Dst: "8.8.8.8:53", RxPkts: 5, RxBytes: 500},
+			},
+		},
+	}
+
+	server.ResponseBody = map[string]any{"logs": expectedLogs}
+
+	params := NetworkFlowLogsRequest{
+		Start: now.Add(-1 * time.Hour),
+		End:   now,
+	}
+
+	var actualLogs []NetworkFlowLog
+	handler := func(log NetworkFlowLog) error {
+		actualLogs = append(actualLogs, log)
+		return nil
+	}
+
+	err := client.Logging().GetNetworkFlowLogs(context.Background(), params, handler)
+	assert.NoError(t, err)
+	assert.Equal(t, http.MethodGet, server.Method)
+	assert.Equal(t, "/api/v2/tailnet/example.com/logging/network", server.Path)
+	
+	assert.Len(t, actualLogs, 2)
+	assert.Equal(t, expectedLogs, actualLogs)
+}
+
+func TestClient_GetNetworkFlowLogs_HandlerError(t *testing.T) {
+	t.Parallel()
+
+	client, server := NewTestHarness(t)
+	server.ResponseCode = http.StatusOK
+
+	now := time.Now().UTC()
+	server.ResponseBody = map[string]any{
+		"logs": []NetworkFlowLog{{
+			Logged: now, NodeID: "test-node", Start: now.Add(-5 * time.Minute), End: now,
+		}},
+	}
+
+	params := NetworkFlowLogsRequest{Start: now.Add(-1 * time.Hour), End: now}
+
+	handler := func(log NetworkFlowLog) error {
+		return fmt.Errorf("test handler error")
+	}
+
+	err := client.Logging().GetNetworkFlowLogs(context.Background(), params, handler)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "handler error")
+	assert.Contains(t, err.Error(), "test handler error")
+}
+
+


### PR DESCRIPTION
Adds support for the network flow logs API endpoint at /api/v2/tailnet/{tailnet}/logging/network. This endpoint returns network traffic flow data including virtual, subnet, exit, and physical traffic with packet/byte counts.

Updates #41