### PR TITLE
client: support leaving Tailnet empty to use default tailnet

### DIFF
--- a/client.go
+++ b/client.go
@@ -30,7 +30,9 @@ type Client struct {
 	// APIKey allows specifying an APIKey to use for authentication.
 	// To use OAuth Client credentials, construct an [http.Client] using [OAuthConfig] and specify that below.
 	APIKey string
-	// Tailnet allows specifying a specific Tailnet by name, to which this Client will connect by default.
+	// Tailnet allows specifying a specific tailnet by name, to which this Client will connect by default.
+	// If Tailnet is left blank, the client will connect to default tailnet based on the client's credential,
+	// using the "-" (dash) default tailnet path.
 	Tailnet string
 
 	// HTTP is the [http.Client] to use for requests to the API server.
@@ -91,6 +93,9 @@ func (c *Client) init() {
 		}
 		if c.HTTP == nil {
 			c.HTTP = &http.Client{Timeout: defaultHttpClientTimeout}
+		}
+		if c.Tailnet == "" {
+			c.Tailnet = "-"
 		}
 		c.contacts = &ContactsResource{c}
 		c.devicePosture = &DevicePostureResource{c}

--- a/client_test.go
+++ b/client_test.go
@@ -52,3 +52,19 @@ func Test_BuildTailnetURL(t *testing.T) {
 	require.NoError(t, err)
 	assert.EqualValues(t, expected.String(), actual.String())
 }
+
+func Test_BuildTailnetURLDefault(t *testing.T) {
+	t.Parallel()
+
+	base, err := url.Parse("http://example.com")
+	require.NoError(t, err)
+
+	c := &Client{
+		BaseURL: base,
+	}
+	c.init()
+	actual := c.buildTailnetURL("path")
+	expected, err := url.Parse("http://example.com/api/v2/tailnet/-/path")
+	require.NoError(t, err)
+	assert.EqualValues(t, expected.String(), actual.String())
+}


### PR DESCRIPTION
If users leave the Tailnet setting blank, the client will connect to the default tailnet of the credential, using the "-" (dash) tailnet path.

Updates tailscale/tailscale#16950