### PR TITLE
dns: add HTTPSCertificates to DNSPreferences

### DIFF
--- a/dns.go
+++ b/dns.go
@@ -20,7 +20,8 @@ type SplitDNSRequest map[string][]string
 type SplitDNSResponse SplitDNSRequest
 
 type DNSPreferences struct {
-	MagicDNS bool `json:"magicDNS"`
+	MagicDNS          bool `json:"magicDNS"`
+	HTTPSCertificates bool `json:"HTTPSCertificates"`
 }
 
 // SetSearchPaths replaces the list of search paths with the list supplied by the user and returns an error otherwise.
@@ -137,8 +138,8 @@ func (dr *DNSResource) Preferences(ctx context.Context) (*DNSPreferences, error)
 	return body[DNSPreferences](dr, req)
 }
 
-// SetPreferences replaces the DNS preferences for the tailnet, specifically, the MagicDNS setting. Note that MagicDNS
-// is dependent on DNS servers.
+// SetPreferences replaces the DNS preferences for the tailnet, specifically, the MagicDNS
+// and HTTPSCertificates settings. Note that MagicDNS is dependent on DNS servers.
 func (dr *DNSResource) SetPreferences(ctx context.Context, preferences DNSPreferences) error {
 	req, err := dr.buildRequest(ctx, http.MethodPost, dr.buildTailnetURL("dns", "preferences"), requestBody(preferences))
 	if err != nil {
@@ -161,8 +162,9 @@ type DNSConfigurationResolver struct {
 }
 
 type DNSConfigurationPreferences struct {
-	OverrideLocalDNS bool `json:"overrideLocalDNS,omitempty"`
-	MagicDNS         bool `json:"magicDNS,omitempty"`
+	OverrideLocalDNS  bool `json:"overrideLocalDNS,omitempty"`
+	MagicDNS          bool `json:"magicDNS,omitempty"`
+	HTTPSCertificates bool `json:"HTTPSCertificates,omitempty"`
 }
 
 // Configuration retrieves the tailnet's complete DNS configuration.

--- a/dns_test.go
+++ b/dns_test.go
@@ -36,7 +36,8 @@ func TestClient_DNSPreferences(t *testing.T) {
 	client, server := NewTestHarness(t)
 	server.ResponseCode = http.StatusOK
 	server.ResponseBody = &DNSPreferences{
-		MagicDNS: true,
+		MagicDNS:          true,
+		HTTPSCertificates: true,
 	}
 
 	preferences, err := client.DNS().Preferences(context.Background())
@@ -107,7 +108,8 @@ func TestClient_SetDNSPreferences(t *testing.T) {
 	server.ResponseCode = http.StatusOK
 
 	preferences := DNSPreferences{
-		MagicDNS: true,
+		MagicDNS:          true,
+		HTTPSCertificates: true,
 	}
 
 	assert.NoError(t, client.DNS().SetPreferences(context.Background(), preferences))
@@ -204,8 +206,9 @@ func TestClient_DNSConfiguration(t *testing.T) {
 			},
 		},
 		Preferences: DNSConfigurationPreferences{
-			OverrideLocalDNS: true,
-			MagicDNS:         true,
+			OverrideLocalDNS:  true,
+			MagicDNS:          true,
+			HTTPSCertificates: true,
 		},
 	}
 
@@ -238,8 +241,9 @@ func TestClient_SetDNSConfiguration(t *testing.T) {
 			},
 		},
 		Preferences: DNSConfigurationPreferences{
-			OverrideLocalDNS: true,
-			MagicDNS:         true,
+			OverrideLocalDNS:  true,
+			MagicDNS:          true,
+			HTTPSCertificates: true,
 		},
 	}
 


### PR DESCRIPTION
This adds a boolean HTTPSCertificates to the DNSPreferences. Adding it there because that's what the FR suggests and because it makes as DNSPreferences already holds the other boolean switch in the DNS settings, MagicDNS.

Updates #449