### PR TITLE
identityfederation: added a utility method to perform the token exchange

### DIFF
--- a/identityfederation.go
+++ b/identityfederation.go
@@ -1,0 +1,184 @@
+// Copyright (c) David Bond, Tailscale Inc, & Contributors
+// SPDX-License-Identifier: MIT
+
+package tailscale
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+)
+
+// IdentityFederationConfig encapsulates the configuration needed to obtain a Tailscale API token via workload identity federation.
+type IdentityFederationConfig struct {
+	// ClientID is the client ID of the federated identity Tailscale OAuth client.
+	ClientID string
+	// IDTokenFunc returns an identity token from the IdP to exchange for a Tailscale API token.
+	// The client calls this function to obtain a fresh ID token and reauthenticate when the API token
+	// and cached ID token have expired. For static tokens, return the token directly. If a static token
+	// expires, the client cannot automatically refresh the API token; the consumer is responsible to create a new client
+	// with a fresh ID token.
+	IDTokenFunc func() (string, error)
+	// BaseURL is an optional base URL for the API server to which we'll connect. Defaults to https://api.tailscale.com.
+	BaseURL string
+}
+
+// TokenExchangeResponse represents the response from the Tailscale token exchange endpoint.
+type TokenExchangeResponse struct {
+	AccessToken string `json:"access_token"`
+	TokenType   string `json:"token_type"`
+	ExpiresIn   int    `json:"expires_in"` // in seconds
+	Scope       string `json:"scope"`
+}
+
+// jwtClaims represents the claims in a JWT token (minimal set for validation).
+type jwtClaims struct {
+	Exp int64 `json:"exp"`
+}
+
+// tokenTransport implements http.RoundTripper and handles token exchange and caching.
+type tokenTransport struct {
+	config    IdentityFederationConfig
+	transport http.RoundTripper
+
+	idToken        string
+	apiAccessToken string
+	expiresAt      time.Time
+
+	tokenRefreshMu sync.Mutex
+}
+
+// HTTPClient constructs an HTTP client that authenticates using identity federation.
+// The client automatically handles token exchange and caching.
+func (c IdentityFederationConfig) HTTPClient() (*http.Client, error) {
+	if c.ClientID == "" {
+		return nil, fmt.Errorf("ClientID is required")
+	}
+	if c.IDTokenFunc == nil {
+		return nil, fmt.Errorf("IDTokenFunc is required")
+	}
+	if c.BaseURL == "" {
+		c.BaseURL = defaultBaseURL.String()
+	}
+
+	transport := &tokenTransport{
+		config:    c,
+		transport: http.DefaultTransport,
+	}
+
+	// Perform initial token exchange to validate configuration early
+	if err := transport.refreshToken(context.Background()); err != nil {
+		return nil, err
+	}
+
+	return &http.Client{
+		Transport: transport,
+		Timeout:   defaultHttpClientTimeout,
+	}, nil
+}
+
+// RoundTrip executes a single HTTP transaction, refreshing the API access token if necessary.
+func (t *tokenTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if t.apiAccessToken == "" || time.Now().After(t.expiresAt) {
+		if err := t.refreshToken(req.Context()); err != nil {
+			return nil, err
+		}
+	}
+
+	reqClone := req.Clone(req.Context())
+	reqClone.Header.Set("Authorization", "Bearer "+t.apiAccessToken)
+
+	return t.transport.RoundTrip(reqClone)
+}
+
+// refreshToken performs the token exchange and updates the cached token.
+func (t *tokenTransport) refreshToken(ctx context.Context) error {
+	t.tokenRefreshMu.Lock()
+	defer t.tokenRefreshMu.Unlock()
+
+	if t.idToken == "" || validateIDToken(t.idToken) != nil {
+		idToken, err := t.config.IDTokenFunc()
+		if err != nil {
+			return fmt.Errorf("failed to fetch ID token: %w", err)
+		}
+		if err := validateIDToken(idToken); err != nil {
+			return fmt.Errorf("fetched ID token is invalid: %w", err)
+		}
+		t.idToken = idToken
+	}
+
+	exchangeURL := fmt.Sprintf("%s/api/v2/oauth/token-exchange", t.config.BaseURL)
+	values := url.Values{
+		"client_id": {t.config.ClientID},
+		"jwt":       {t.idToken},
+	}.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, exchangeURL, strings.NewReader(values))
+	if err != nil {
+		return fmt.Errorf("failed to create token exchange request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	client := &http.Client{
+		Transport: t.transport,
+		Timeout:   10 * time.Second,
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("unexpected token exchange request error: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= http.StatusBadRequest {
+		b, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("token exchange failed with status %d: %s", resp.StatusCode, string(b))
+	}
+
+	var tokenResp TokenExchangeResponse
+	if err = json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
+		return fmt.Errorf("failed to decode token exchange response: %w", err)
+	}
+
+	t.apiAccessToken = tokenResp.AccessToken
+	// Set expiration with a 5-minute buffer for safety
+	t.expiresAt = time.Now().Add(time.Duration(tokenResp.ExpiresIn)*time.Second - 5*time.Minute)
+
+	return nil
+}
+
+// validateIDToken decodes and validates the ID token's expiration claim
+// to give a more helpful error if the token is expired or malformed.
+func validateIDToken(idToken string) error {
+	parts := strings.Split(idToken, ".")
+	if len(parts) != 3 {
+		return fmt.Errorf("invalid JWT format: expected 3 parts separated by '.', got %d", len(parts))
+	}
+
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return fmt.Errorf("failed to decode JWT payload: %w", err)
+	}
+
+	var claims jwtClaims
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return fmt.Errorf("failed to parse JWT claims: %w", err)
+	}
+
+	if claims.Exp == 0 {
+		return fmt.Errorf("JWT is missing 'exp' (expiration) claim")
+	}
+
+	expirationTime := time.Unix(claims.Exp, 0)
+	if time.Now().After(expirationTime) {
+		return fmt.Errorf("ID token has expired (expired at %s)", expirationTime.Format(time.RFC3339))
+	}
+
+	return nil
+}

--- a/identityfederation_test.go
+++ b/identityfederation_test.go
@@ -1,0 +1,352 @@
+// Copyright (c) David Bond, Tailscale Inc, & Contributors
+// SPDX-License-Identifier: MIT
+
+package tailscale
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateIDToken(t *testing.T) {
+	t.Run("valid token", func(t *testing.T) {
+		futureExp := time.Now().Add(1 * time.Hour).Unix()
+
+		err := validateIDToken(createIDToken(futureExp))
+
+		require.NoError(t, err)
+	})
+
+	t.Run("expired token", func(t *testing.T) {
+		pastExp := time.Now().Add(-1 * time.Hour).Unix()
+
+		err := validateIDToken(createIDToken(pastExp))
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "expired")
+	})
+
+	t.Run("missing exp claim", func(t *testing.T) {
+		header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"HS256","typ":"JWT"}`))
+		payload := base64.RawURLEncoding.EncodeToString([]byte(`{}`))
+		signature := base64.RawURLEncoding.EncodeToString([]byte("fake-signature"))
+		token := fmt.Sprintf("%s.%s.%s", header, payload, signature)
+
+		err := validateIDToken(token)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "missing 'exp'")
+	})
+
+	t.Run("invalid JWT format - too few parts", func(t *testing.T) {
+		err := validateIDToken("invalid.token")
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid JWT format")
+	})
+
+	t.Run("invalid JWT format - too many parts", func(t *testing.T) {
+		err := validateIDToken("part1.part2.part3.part4")
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid JWT format")
+	})
+
+	t.Run("invalid base64 in payload", func(t *testing.T) {
+		err := validateIDToken("header.invalid-base64!@#.signature")
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to decode JWT payload")
+	})
+
+	t.Run("invalid JSON in payload", func(t *testing.T) {
+		header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"HS256"}`))
+		payload := base64.RawURLEncoding.EncodeToString([]byte(`{invalid json`))
+		signature := base64.RawURLEncoding.EncodeToString([]byte("sig"))
+		token := fmt.Sprintf("%s.%s.%s", header, payload, signature)
+
+		err := validateIDToken(token)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to parse JWT claims")
+	})
+}
+
+func TestHTTPClient(t *testing.T) {
+	validToken := createIDToken(time.Now().Add(1 * time.Hour).Unix())
+
+	t.Run("success with static ID token", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/api/v2/oauth/token-exchange" {
+				json.NewEncoder(w).Encode(TokenExchangeResponse{
+					AccessToken: "ts-api-test-token",
+					TokenType:   "Bearer",
+					ExpiresIn:   3600,
+				})
+			}
+		}))
+		defer srv.Close()
+
+		client, err := IdentityFederationConfig{
+			ClientID: "test-client-id",
+			IDTokenFunc: func() (string, error) {
+				return validToken, nil
+			},
+			BaseURL: srv.URL,
+		}.HTTPClient()
+
+		require.NoError(t, err)
+		require.NotNil(t, client)
+	})
+
+	t.Run("success with token generator", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/api/v2/oauth/token-exchange" {
+				json.NewEncoder(w).Encode(TokenExchangeResponse{
+					AccessToken: "ts-api-test-token",
+					TokenType:   "Bearer",
+					ExpiresIn:   3600,
+				})
+			}
+		}))
+		defer srv.Close()
+
+		generatorCalled := false
+		client, err := IdentityFederationConfig{
+			ClientID: "test-client-id",
+			IDTokenFunc: func() (string, error) {
+				generatorCalled = true
+				return validToken, nil
+			},
+			BaseURL: srv.URL,
+		}.HTTPClient()
+
+		require.NoError(t, err)
+		require.NotNil(t, client)
+		assert.True(t, generatorCalled, "generator should be called during initialization")
+	})
+
+	t.Run("missing client ID", func(t *testing.T) {
+		_, err := IdentityFederationConfig{
+			IDTokenFunc: func() (string, error) {
+				return validToken, nil
+			},
+		}.HTTPClient()
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "ClientID is required")
+	})
+
+	t.Run("missing IDTokenFunc", func(t *testing.T) {
+		_, err := IdentityFederationConfig{
+			ClientID: "test-client-id",
+		}.HTTPClient()
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "IDTokenFunc is required")
+	})
+
+	t.Run("expired ID token", func(t *testing.T) {
+		expiredToken := createIDToken(time.Now().Add(-1 * time.Hour).Unix())
+
+		_, err := IdentityFederationConfig{
+			ClientID: "test-client-id",
+			IDTokenFunc: func() (string, error) {
+				return expiredToken, nil
+			},
+		}.HTTPClient()
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "expired")
+	})
+
+	t.Run("generator returns error", func(t *testing.T) {
+		_, err := IdentityFederationConfig{
+			ClientID: "test-client-id",
+			IDTokenFunc: func() (string, error) {
+				return "", fmt.Errorf("generator error")
+			},
+		}.HTTPClient()
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to fetch ID token")
+		assert.Contains(t, err.Error(), "generator error")
+	})
+
+	t.Run("invalid JWT format", func(t *testing.T) {
+		_, err := IdentityFederationConfig{
+			ClientID: "test-client-id",
+			IDTokenFunc: func() (string, error) {
+				return "not.a.valid.jwt", nil
+			},
+		}.HTTPClient()
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid JWT format")
+	})
+}
+
+func TestTokenTransportRoundTrip(t *testing.T) {
+	validToken := createIDToken(time.Now().Add(1 * time.Hour).Unix())
+
+	t.Run("adds token to request using bearer token", func(t *testing.T) {
+		var capturedAuthHeader string
+		apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedAuthHeader = r.Header.Get("Authorization")
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer apiSrv.Close()
+
+		tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/api/v2/oauth/token-exchange" {
+				json.NewEncoder(w).Encode(TokenExchangeResponse{
+					AccessToken: "test-access-token",
+					TokenType:   "Bearer",
+					ExpiresIn:   3600,
+				})
+			}
+		}))
+		defer tokenSrv.Close()
+
+		httpClient, err := IdentityFederationConfig{
+			ClientID: "test-client-id",
+			IDTokenFunc: func() (string, error) {
+				return validToken, nil
+			},
+			BaseURL: tokenSrv.URL,
+		}.HTTPClient()
+		require.NoError(t, err)
+
+		req, _ := http.NewRequest("GET", apiSrv.URL, nil)
+		_, err = httpClient.Do(req)
+		require.NoError(t, err)
+
+		assert.Equal(t, "Bearer test-access-token", capturedAuthHeader)
+	})
+
+	t.Run("generator called on expired token", func(t *testing.T) {
+		freshToken := createIDToken(time.Now().Add(1 * time.Hour).Unix())
+
+		generatorCallCount := 0
+		tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/api/v2/oauth/token-exchange" {
+				json.NewEncoder(w).Encode(TokenExchangeResponse{
+					AccessToken: "test-access-token",
+					TokenType:   "Bearer",
+					ExpiresIn:   3600,
+				})
+			}
+		}))
+		defer tokenSrv.Close()
+
+		httpClient, err := IdentityFederationConfig{
+			ClientID: "test-client-id",
+			IDTokenFunc: func() (string, error) {
+				generatorCallCount++
+				return freshToken, nil
+			},
+			BaseURL: tokenSrv.URL,
+		}.HTTPClient()
+		require.NoError(t, err)
+
+		// Initial call should use generator
+		assert.Equal(t, 1, generatorCallCount)
+
+		// Manually expire the access token to trigger refresh
+		transport := httpClient.Transport.(*tokenTransport)
+		transport.expiresAt = time.Now().Add(-1 * time.Minute)
+
+		// Make a request - should trigger refresh but reuse cached ID token
+		apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer apiSrv.Close()
+
+		req, _ := http.NewRequest("GET", apiSrv.URL, nil)
+		_, err = httpClient.Do(req)
+		require.NoError(t, err)
+
+		// Generator should still be 1 because ID token is cached and still valid
+		assert.Equal(t, 1, generatorCallCount)
+	})
+
+	t.Run("generator called when cached ID token expires", func(t *testing.T) {
+		expiredToken := createIDToken(time.Now().Add(-1 * time.Hour).Unix())
+		freshToken := createIDToken(time.Now().Add(1 * time.Hour).Unix())
+
+		generatorCallCount := 0
+		tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/api/v2/oauth/token-exchange" {
+				json.NewEncoder(w).Encode(TokenExchangeResponse{
+					AccessToken: "test-access-token",
+					TokenType:   "Bearer",
+					ExpiresIn:   3600,
+				})
+			}
+		}))
+		defer tokenSrv.Close()
+
+		httpClient, err := IdentityFederationConfig{
+			ClientID: "test-client-id",
+			IDTokenFunc: func() (string, error) {
+				generatorCallCount++
+				if generatorCallCount == 1 {
+					return expiredToken, nil
+				}
+				return freshToken, nil
+			},
+			BaseURL: tokenSrv.URL,
+		}.HTTPClient()
+
+		// First call should fail due to expired ID token
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "ID token has expired")
+		assert.Equal(t, 1, generatorCallCount)
+
+		// Now test with a valid initial token that we manually expire
+		generatorCallCount = 0
+		httpClient, err = IdentityFederationConfig{
+			ClientID: "test-client-id",
+			IDTokenFunc: func() (string, error) {
+				generatorCallCount++
+				return freshToken, nil
+			},
+			BaseURL: tokenSrv.URL,
+		}.HTTPClient()
+		require.NoError(t, err)
+		assert.Equal(t, 1, generatorCallCount)
+
+		// Manually expire both the access token and ID token
+		transport := httpClient.Transport.(*tokenTransport)
+		transport.expiresAt = time.Now().Add(-1 * time.Minute)
+		transport.idToken = expiredToken
+
+		// Make a request - should call generator because cached ID token is expired
+		apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer apiSrv.Close()
+
+		req, _ := http.NewRequest("GET", apiSrv.URL, nil)
+		_, err = httpClient.Do(req)
+		require.NoError(t, err)
+
+		// Generator should now be 2 because expired ID token was refreshed
+		assert.Equal(t, 2, generatorCallCount)
+	})
+}
+
+func createIDToken(exp int64) string {
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"HS256","typ":"JWT"}`))
+	payload := base64.RawURLEncoding.EncodeToString([]byte(fmt.Sprintf(`{"exp":%d}`, exp)))
+	signature := base64.RawURLEncoding.EncodeToString([]byte("fake-signature"))
+	return fmt.Sprintf("%s.%s.%s", header, payload, signature)
+}


### PR DESCRIPTION
Updates tailscale/terraform-provider-tailscale#485

See https://github.com/tailscale/terraform-provider-tailscale/pull/567 for usage example. At first I implemented the token exchange in the provider directly but the small `GenerateAccessToken` is generally useful and aligns with the small OauthConfig utility to help setup different auth options when instantiating the Tailscale client.

Bumped go and some dependencies as a drive-by.