### PR TITLE
simplify configuration of oauth clients, support identity federation

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,67 @@ import (
 func main() {
 	client := &tailscale.Client{
 		Tailnet: os.Getenv("TAILSCALE_TAILNET"),
-		HTTP:    tailscale.OAuthConfig{
+		Auth: &tailscale.OAuth{
 			ClientID:     os.Getenv("TAILSCALE_OAUTH_CLIENT_ID"),
 			ClientSecret: os.Getenv("TAILSCALE_OAUTH_CLIENT_SECRET"),
 			Scopes:       []string{"all:write"},
-		}.HTTPClient(),
+		},
+	}
+	
+	devices, err := client.Devices().List(context.Background())
+}
+```
+
+## Example (Using Identity Federation)
+
+```go
+package main
+
+import (
+	"context"
+	"os"
+
+	"tailscale.com/client/tailscale/v2"
+)
+
+func main() {
+	client := &tailscale.Client{
+		Tailnet: os.Getenv("TAILSCALE_TAILNET"),
+		Auth: &tailscale.IdentityFederation{
+			ClientID: os.Getenv("TAILSCALE_OAUTH_CLIENT_ID"),
+			IDTokenFunc: func() (string, error) {
+				return os.Getenv("IDENTITY_TOKEN"), nil
+            },
+		},
+	}
+
+	devices, err := client.Devices().List(context.Background())
+}
+```
+
+## Example (Using Your Own Authentication Mechanism)
+
+```go
+package main
+
+import (
+	"context"
+	"os"
+
+	"tailscale.com/client/tailscale/v2"
+)
+
+type MyAuth struct {...}
+
+func (a *MyAuth) HTTPClient(orig *http.Client, baseURL string) *http.Client {
+	// build an HTTP client that adds authentication to outgoing requests
+	// see tailscale.OAuth for an example.
+}
+
+func main() {
+	client := &tailscale.Client{
+		Tailnet: os.Getenv("TAILSCALE_TAILNET"),
+		Auth: &MyAuth{...},
 	}
 	
 	devices, err := client.Devices().List(context.Background())

--- a/identityfederation.go
+++ b/identityfederation.go
@@ -1,0 +1,158 @@
+// Copyright (c) David Bond, Tailscale Inc, & Contributors
+// SPDX-License-Identifier: MIT
+
+package tailscale
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/oauth2"
+)
+
+var _ Auth = &IdentityFederation{}
+
+// tokenExchangeResponse represents the response from the Tailscale token exchange endpoint.
+type tokenExchangeResponse struct {
+	AccessToken string `json:"access_token"`
+	TokenType   string `json:"token_type"`
+	ExpiresIn   int    `json:"expires_in"` // in seconds
+	Scope       string `json:"scope"`
+}
+
+// jwtClaims represents the claims in a JWT token (minimal set for validation).
+type jwtClaims struct {
+	Exp int64 `json:"exp"`
+}
+
+// IdentityFederation configures identity federation authentication.
+type IdentityFederation struct {
+	// ClientID is the ID of the Tailscale OAuth client.
+	ClientID string
+	// IDTokenFunc returns an identity token from the IdP to exchange for a Tailscale API token.
+	// The client calls this function to obtain a fresh ID token and reauthenticate when the API token
+	// and cached ID token have expired. For static tokens, return the token directly. If a static token
+	// expires, the client cannot automatically refresh the API token; the consumer is responsible to create a new client
+	// with a fresh ID token.
+	IDTokenFunc func() (string, error)
+}
+
+// identityFederationTokenSource implements oauth2.TokenSource using identity federation.
+type identityFederationTokenSource struct {
+	http        *http.Client
+	baseURL     string
+	clientID    string
+	idTokenFunc func() (string, error)
+
+	mu      sync.Mutex // protects the below fields
+	idToken string
+}
+
+// HTTPClient implements the [Auth] interface.
+func (i *IdentityFederation) HTTPClient(orig *http.Client, baseURL string) *http.Client {
+	s := &identityFederationTokenSource{
+		http:        orig,
+		baseURL:     baseURL,
+		clientID:    i.ClientID,
+		idTokenFunc: i.IDTokenFunc,
+	}
+
+	return &http.Client{
+		Transport: &oauth2.Transport{
+			Base:   orig.Transport,
+			Source: oauth2.ReuseTokenSource(nil, s),
+		},
+		CheckRedirect: orig.CheckRedirect,
+		Jar:           orig.Jar,
+		Timeout:       orig.Timeout,
+	}
+}
+
+// Token implements oauth2.TokenSource by exchanging an ID token for an API access token.
+func (i *identityFederationTokenSource) Token() (*oauth2.Token, error) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	if i.idToken == "" || validateIDToken(i.idToken) != nil {
+		idToken, err := i.idTokenFunc()
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch ID token: %w", err)
+		}
+		if err := validateIDToken(idToken); err != nil {
+			return nil, fmt.Errorf("fetched ID token is invalid: %w", err)
+		}
+		i.idToken = idToken
+	}
+
+	exchangeURL := fmt.Sprintf("%s/api/v2/oauth/token-exchange", i.baseURL)
+	values := url.Values{
+		"client_id": {i.clientID},
+		"jwt":       {i.idToken},
+	}.Encode()
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, exchangeURL, strings.NewReader(values))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create token exchange request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := i.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("unexpected token exchange request error: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= http.StatusBadRequest {
+		b, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("token exchange failed with status %d: %s", resp.StatusCode, string(b))
+	}
+
+	var tokenResp tokenExchangeResponse
+	if err = json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
+		return nil, fmt.Errorf("failed to decode token exchange response: %w", err)
+	}
+
+	return &oauth2.Token{
+		AccessToken: tokenResp.AccessToken,
+		TokenType:   tokenResp.TokenType,
+		Expiry:      time.Now().Add(time.Duration(tokenResp.ExpiresIn) * time.Second),
+	}, nil
+}
+
+// validateIDToken decodes and validates the ID token's expiration claim
+// to give a more helpful error if the token is expired or malformed.
+func validateIDToken(idToken string) error {
+	parts := strings.Split(idToken, ".")
+	if len(parts) != 3 {
+		return fmt.Errorf("invalid JWT format: expected 3 parts separated by '.', got %d", len(parts))
+	}
+
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return fmt.Errorf("failed to decode JWT payload: %w", err)
+	}
+
+	var claims jwtClaims
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return fmt.Errorf("failed to parse JWT claims: %w", err)
+	}
+
+	if claims.Exp == 0 {
+		return fmt.Errorf("JWT is missing 'exp' (expiration) claim")
+	}
+
+	expirationTime := time.Unix(claims.Exp, 0)
+	if time.Now().After(expirationTime) {
+		return fmt.Errorf("ID token has expired (expired at %s)", expirationTime.Format(time.RFC3339))
+	}
+
+	return nil
+}

--- a/identityfederation_test.go
+++ b/identityfederation_test.go
@@ -1,0 +1,478 @@
+// Copyright (c) David Bond, Tailscale Inc, & Contributors
+// SPDX-License-Identifier: MIT
+
+package tailscale
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateIDToken(t *testing.T) {
+	t.Run("valid token", func(t *testing.T) {
+		futureExp := time.Now().Add(1 * time.Hour).Unix()
+
+		err := validateIDToken(createIDToken(futureExp))
+
+		require.NoError(t, err)
+	})
+
+	t.Run("expired token", func(t *testing.T) {
+		pastExp := time.Now().Add(-1 * time.Hour).Unix()
+
+		err := validateIDToken(createIDToken(pastExp))
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "expired")
+	})
+
+	t.Run("missing exp claim", func(t *testing.T) {
+		header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"HS256","typ":"JWT"}`))
+		payload := base64.RawURLEncoding.EncodeToString([]byte(`{}`))
+		signature := base64.RawURLEncoding.EncodeToString([]byte("fake-signature"))
+		token := fmt.Sprintf("%s.%s.%s", header, payload, signature)
+
+		err := validateIDToken(token)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "missing 'exp'")
+	})
+
+	t.Run("invalid JWT format - too few parts", func(t *testing.T) {
+		err := validateIDToken("invalid.token")
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid JWT format")
+	})
+
+	t.Run("invalid JWT format - too many parts", func(t *testing.T) {
+		err := validateIDToken("part1.part2.part3.part4")
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid JWT format")
+	})
+
+	t.Run("invalid base64 in payload", func(t *testing.T) {
+		err := validateIDToken("header.invalid-base64!@#.signature")
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to decode JWT payload")
+	})
+
+	t.Run("invalid JSON in payload", func(t *testing.T) {
+		header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"HS256"}`))
+		payload := base64.RawURLEncoding.EncodeToString([]byte(`{invalid json`))
+		signature := base64.RawURLEncoding.EncodeToString([]byte("sig"))
+		token := fmt.Sprintf("%s.%s.%s", header, payload, signature)
+
+		err := validateIDToken(token)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to parse JWT claims")
+	})
+}
+
+func TestClientWithIdentityFederation(t *testing.T) {
+	validToken := createIDToken(time.Now().Add(1 * time.Hour).Unix())
+
+	t.Run("success with static ID token", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/api/v2/oauth/token-exchange" {
+				err := json.NewEncoder(w).Encode(tokenExchangeResponse{
+					AccessToken: "ts-api-test-token",
+					TokenType:   "Bearer",
+					ExpiresIn:   3600,
+				})
+				if err != nil {
+					t.Fatalf("failed to encode response: %v", err)
+				}
+			} else {
+				w.WriteHeader(http.StatusOK)
+			}
+		}))
+		defer srv.Close()
+
+		baseURL, _ := url.Parse(srv.URL)
+		client := &Client{
+			Auth: &IdentityFederation{
+				ClientID: "test-client-id",
+				IDTokenFunc: func() (string, error) {
+					return validToken, nil
+				},
+			},
+			BaseURL: baseURL,
+		}
+
+		// Make a request to trigger transport initialization
+		req, _ := http.NewRequest("GET", srv.URL+"/test", nil)
+		client.init()
+		_, err := client.HTTP.Do(req)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("success with token generator", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/api/v2/oauth/token-exchange" {
+				err := json.NewEncoder(w).Encode(tokenExchangeResponse{
+					AccessToken: "ts-api-test-token",
+					TokenType:   "Bearer",
+					ExpiresIn:   3600,
+				})
+				if err != nil {
+					t.Fatalf("failed to encode response: %v", err)
+				}
+			} else {
+				w.WriteHeader(http.StatusOK)
+			}
+		}))
+		defer srv.Close()
+
+		generatorCalled := false
+		baseURL, _ := url.Parse(srv.URL)
+		client := &Client{
+			Auth: &IdentityFederation{
+				ClientID: "test-client-id",
+				IDTokenFunc: func() (string, error) {
+					generatorCalled = true
+					return validToken, nil
+				},
+			},
+			BaseURL: baseURL,
+		}
+
+		// Make a request to trigger token exchange
+		req, _ := http.NewRequest("GET", srv.URL+"/test", nil)
+		client.init()
+		_, err := client.HTTP.Do(req)
+
+		require.NoError(t, err)
+		assert.True(t, generatorCalled, "generator should be called during first request")
+	})
+
+	t.Run("expired ID token on first request", func(t *testing.T) {
+		expiredToken := createIDToken(time.Now().Add(-1 * time.Hour).Unix())
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer srv.Close()
+
+		baseURL, _ := url.Parse(srv.URL)
+		client := &Client{
+			Auth: &IdentityFederation{
+				ClientID: "test-client-id",
+				IDTokenFunc: func() (string, error) {
+					return expiredToken, nil
+				},
+			},
+			BaseURL: baseURL,
+		}
+
+		// Make a request to trigger token exchange
+		req, _ := http.NewRequest("GET", srv.URL+"/test", nil)
+		client.init()
+		_, err := client.HTTP.Do(req)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "expired")
+	})
+
+	t.Run("generator returns error", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer srv.Close()
+
+		baseURL, _ := url.Parse(srv.URL)
+		client := &Client{
+			Auth: &IdentityFederation{
+				ClientID: "test-client-id",
+				IDTokenFunc: func() (string, error) {
+					return "", fmt.Errorf("generator error")
+				},
+			},
+			BaseURL: baseURL,
+		}
+
+		// Make a request to trigger token exchange
+		req, _ := http.NewRequest("GET", srv.URL+"/test", nil)
+		client.init()
+		_, err := client.HTTP.Do(req)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to fetch ID token")
+		assert.Contains(t, err.Error(), "generator error")
+	})
+
+	t.Run("invalid JWT format", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer srv.Close()
+
+		baseURL, _ := url.Parse(srv.URL)
+		client := &Client{
+			Auth: &IdentityFederation{
+				ClientID: "test-client-id",
+				IDTokenFunc: func() (string, error) {
+					return "not.a.valid.jwt", nil
+				},
+			},
+			BaseURL: baseURL,
+		}
+
+		// Make a request to trigger token exchange
+		req, _ := http.NewRequest("GET", srv.URL+"/test", nil)
+		client.init()
+		_, err := client.HTTP.Do(req)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid JWT format")
+	})
+}
+
+func TestTokenTransportRoundTrip(t *testing.T) {
+	validToken := createIDToken(time.Now().Add(1 * time.Hour).Unix())
+
+	t.Run("adds token to request using bearer token", func(t *testing.T) {
+		var capturedAuthHeader string
+		apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedAuthHeader = r.Header.Get("Authorization")
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer apiSrv.Close()
+
+		tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/api/v2/oauth/token-exchange" {
+				err := json.NewEncoder(w).Encode(tokenExchangeResponse{
+					AccessToken: "test-access-token",
+					TokenType:   "Bearer",
+					ExpiresIn:   3600,
+				})
+				if err != nil {
+					t.Fatalf("failed to encode response: %v", err)
+				}
+			}
+		}))
+		defer tokenSrv.Close()
+
+		baseURL, _ := url.Parse(tokenSrv.URL)
+		client := &Client{
+			Auth: &IdentityFederation{
+				ClientID: "test-client-id",
+				IDTokenFunc: func() (string, error) {
+					return validToken, nil
+				},
+			},
+			BaseURL: baseURL,
+		}
+		client.init()
+
+		req, _ := http.NewRequest("GET", apiSrv.URL, nil)
+		_, err := client.HTTP.Do(req)
+		require.NoError(t, err)
+
+		assert.Equal(t, "Bearer test-access-token", capturedAuthHeader)
+	})
+
+	t.Run("generator called on expired token", func(t *testing.T) {
+		freshToken := createIDToken(time.Now().Add(1 * time.Hour).Unix())
+
+		generatorCallCount := 0
+		var exchangeCount atomic.Int64
+		tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/api/v2/oauth/token-exchange" {
+				exchangeCount.Add(1)
+				// First exchange returns a token that expires in 1 second
+				// Second exchange returns a token that expires in 1 hour
+				expiresIn := 1
+				if exchangeCount.Load() > 1 {
+					expiresIn = 3600
+				}
+				err := json.NewEncoder(w).Encode(tokenExchangeResponse{
+					AccessToken: "test-access-token",
+					TokenType:   "Bearer",
+					ExpiresIn:   expiresIn,
+				})
+				if err != nil {
+					t.Fatalf("failed to encode response: %v", err)
+				}
+			}
+		}))
+		defer tokenSrv.Close()
+
+		baseURL, _ := url.Parse(tokenSrv.URL)
+		client := &Client{
+			Auth: &IdentityFederation{
+				ClientID: "test-client-id",
+				IDTokenFunc: func() (string, error) {
+					generatorCallCount++
+					return freshToken, nil
+				},
+			},
+			BaseURL: baseURL,
+		}
+		client.init()
+
+		// Make initial request to trigger token exchange
+		apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer apiSrv.Close()
+
+		req, _ := http.NewRequest("GET", apiSrv.URL, nil)
+		_, err := client.HTTP.Do(req)
+		require.NoError(t, err)
+
+		// Initial call should use generator
+		assert.Equal(t, 1, generatorCallCount)
+		assert.Equal(t, int64(1), exchangeCount.Load())
+
+		// Wait for token to expire (it was set to expire in 1 second)
+		time.Sleep(2 * time.Second)
+
+		// Make a request - should trigger refresh but reuse cached ID token
+		req, _ = http.NewRequest("GET", apiSrv.URL, nil)
+		_, err = client.HTTP.Do(req)
+		require.NoError(t, err)
+
+		// Generator should still be 1 because ID token is cached and still valid
+		assert.Equal(t, 1, generatorCallCount)
+		// But token exchange should have happened twice
+		assert.Equal(t, int64(2), exchangeCount.Load())
+	})
+
+	t.Run("token source called on expired oauth token", func(t *testing.T) {
+		freshToken := createIDToken(time.Now().Add(1 * time.Hour).Unix())
+
+		var tokenExchangeCallCount atomic.Int64
+		tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/api/v2/oauth/token-exchange" {
+				tokenExchangeCallCount.Add(1)
+				err := json.NewEncoder(w).Encode(tokenExchangeResponse{
+					AccessToken: "test-access-token",
+					TokenType:   "Bearer",
+					ExpiresIn:   3600,
+				})
+				if err != nil {
+					t.Fatalf("failed to encode response: %v", err)
+				}
+			}
+		}))
+		defer tokenSrv.Close()
+
+		baseURL, _ := url.Parse(tokenSrv.URL)
+		client := &Client{
+			Auth: &IdentityFederation{
+				ClientID: "test-client-id",
+				IDTokenFunc: func() (string, error) {
+					return freshToken, nil
+				},
+			},
+			BaseURL: baseURL,
+		}
+		client.init()
+
+		// Make initial request to trigger token exchange
+		apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer apiSrv.Close()
+
+		req, _ := http.NewRequest("GET", apiSrv.URL, nil)
+		_, err := client.HTTP.Do(req)
+		require.NoError(t, err)
+
+		// second request - should reuse the OAuth token
+		req, _ = http.NewRequest("GET", apiSrv.URL, nil)
+		_, err = client.HTTP.Do(req)
+		require.NoError(t, err)
+
+		assert.Equal(t, int64(1), tokenExchangeCallCount.Load())
+	})
+
+	t.Run("generator called when cached ID token expires", func(t *testing.T) {
+		// Create two different tokens - one that's short-lived, one that's long-lived
+		shortLivedToken := createIDToken(time.Now().Add(2 * time.Second).Unix())
+		longLivedToken := createIDToken(time.Now().Add(1 * time.Hour).Unix())
+
+		generatorCallCount := 0
+		var exchangeCount atomic.Int64
+		tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/api/v2/oauth/token-exchange" {
+				exchangeCount.Add(1)
+				// First exchange returns a token that expires in 1 second
+				expiresIn := 1
+				if exchangeCount.Load() > 1 {
+					expiresIn = 3600
+				}
+				err := json.NewEncoder(w).Encode(tokenExchangeResponse{
+					AccessToken: "test-access-token",
+					TokenType:   "Bearer",
+					ExpiresIn:   expiresIn,
+				})
+				if err != nil {
+					t.Fatalf("failed to encode response: %v", err)
+				}
+			}
+		}))
+		defer tokenSrv.Close()
+
+		baseURL, _ := url.Parse(tokenSrv.URL)
+		client := &Client{
+			Auth: &IdentityFederation{
+				ClientID: "test-client-id",
+				IDTokenFunc: func() (string, error) {
+					generatorCallCount++
+					// First call returns short-lived token, second call returns long-lived token
+					if generatorCallCount == 1 {
+						return shortLivedToken, nil
+					}
+					return longLivedToken, nil
+				},
+			},
+			BaseURL: baseURL,
+		}
+		client.init()
+
+		// Make initial request
+		apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer apiSrv.Close()
+
+		req, _ := http.NewRequest("GET", apiSrv.URL, nil)
+		_, err := client.HTTP.Do(req)
+		require.NoError(t, err)
+		assert.Equal(t, 1, generatorCallCount)
+
+		// Wait for both access token AND cached ID token to expire
+		time.Sleep(3 * time.Second)
+
+		// Make a request - should call generator again because cached ID token is expired
+		req, _ = http.NewRequest("GET", apiSrv.URL, nil)
+		_, err = client.HTTP.Do(req)
+		require.NoError(t, err)
+
+		// Generator should now be 2 because expired ID token was refreshed
+		assert.Equal(t, 2, generatorCallCount)
+	})
+}
+
+func createIDToken(exp int64) string {
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"HS256","typ":"JWT"}`))
+	payload := base64.RawURLEncoding.EncodeToString([]byte(fmt.Sprintf(`{"exp":%d}`, exp)))
+	signature := base64.RawURLEncoding.EncodeToString([]byte("fake-signature"))
+	return fmt.Sprintf("%s.%s.%s", header, payload, signature)
+}

--- a/oauth.go
+++ b/oauth.go
@@ -7,10 +7,48 @@ import (
 	"context"
 	"net/http"
 
+	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/clientcredentials"
 )
 
+// Ensure that [OAuth] implements the [Auth] interface.
+var _ Auth = &OAuth{}
+
+// OAuth configures OAuth authentication.
+type OAuth struct {
+	// ClientID is the client ID of the OAuth client.
+	ClientID string
+	// ClientSecret is the client secret of the OAuth client.
+	ClientSecret string
+	// Scopes are the scopes to request when generating tokens for this OAuth client.
+	Scopes []string
+}
+
+// HTTPClient implements the [Auth] interface.
+func (o *OAuth) HTTPClient(orig *http.Client, baseURL string) *http.Client {
+	oauthConfig := clientcredentials.Config{
+		ClientID:     o.ClientID,
+		ClientSecret: o.ClientSecret,
+		Scopes:       o.Scopes,
+		TokenURL:     baseURL + "/api/v2/oauth/token",
+	}
+
+	// Use context.Background() here, since this is used to refresh the token in the future.
+	tokenSource := oauthConfig.TokenSource(context.Background())
+
+	return &http.Client{
+		Transport: &oauth2.Transport{
+			Base:   orig.Transport,
+			Source: oauth2.ReuseTokenSource(nil, tokenSource),
+		},
+		CheckRedirect: orig.CheckRedirect,
+		Jar:           orig.Jar,
+		Timeout:       orig.Timeout,
+	}
+}
+
 // OAuthConfig provides a mechanism for configuring OAuth authentication.
+// Deprecated: use [OAuth] instead.
 type OAuthConfig struct {
 	// ClientID is the client ID of the OAuth client.
 	ClientID string
@@ -23,6 +61,7 @@ type OAuthConfig struct {
 }
 
 // HTTPClient constructs an HTTP client that authenticates using OAuth.
+// Deprecated: use [OAuth] instead.
 func (ocfg OAuthConfig) HTTPClient() *http.Client {
 	baseURL := ocfg.BaseURL
 	if baseURL == "" {


### PR DESCRIPTION
OAuth can now be provided directly to the Client type.

Using OAuthConfig.HTTPClient() is now deprecated.

Updates tailscale/terraform-provider-tailscale#485