### PR TITLE
devices: add SSHEnabled to devices

### DIFF
--- a/devices.go
+++ b/devices.go
@@ -93,6 +93,7 @@ type Device struct {
 	UpdateAvailable           bool     `json:"updateAvailable"`
 
 	// The below are only included in listings when querying `all` fields.
+	SSHEnabled         bool                `json:"sshEnabled"`
 	AdvertisedRoutes   []string            `json:"AdvertisedRoutes"`
 	EnabledRoutes      []string            `json:"enabledRoutes"`
 	ClientConnectivity *ClientConnectivity `json:"clientConnectivity"`

--- a/devices_test.go
+++ b/devices_test.go
@@ -66,6 +66,7 @@ func TestClient_Devices_Get(t *testing.T) {
 		TailnetLockError:          "test error",
 		TailnetLockKey:            "tlpub:test",
 		UpdateAvailable:           true,
+		SSHEnabled: 			   false,
 		AdvertisedRoutes:          []string{"127.0.0.1", "127.0.0.2"},
 		EnabledRoutes:             []string{"127.0.0.1"},
 		ClientConnectivity: &ClientConnectivity{
@@ -172,6 +173,7 @@ func TestClient_Devices_List(t *testing.T) {
 				NodeKey:                   "nodekey:test",
 				OS:                        "windows",
 				UpdateAvailable:           true,
+				SSHEnabled: 			   false,
 				AdvertisedRoutes:          []string{"127.0.0.1", "127.0.0.2"},
 				EnabledRoutes:             []string{"127.0.0.1"},
 				ClientConnectivity: &ClientConnectivity{


### PR DESCRIPTION
SSHEnabled has been added to the devices API when `fields` is set to all

Updates https://github.com/tailscale/tailscale-client-go-v2/issues/39