### PR TITLE
services: Add a services resource with C/R/U/D methods

### DIFF
--- a/client.go
+++ b/client.go
@@ -61,6 +61,7 @@ type Client struct {
 	keys            *KeysResource
 	logging         *LoggingResource
 	policyFile      *PolicyFileResource
+	services        *ServicesResource
 	tailnetSettings *TailnetSettingsResource
 	users           *UsersResource
 	webhooks        *WebhooksResource
@@ -120,6 +121,7 @@ func (c *Client) init() {
 		c.keys = &KeysResource{c}
 		c.logging = &LoggingResource{c}
 		c.policyFile = &PolicyFileResource{c}
+		c.services = &ServicesResource{c}
 		c.tailnetSettings = &TailnetSettingsResource{c}
 		c.users = &UsersResource{c}
 		c.webhooks = &WebhooksResource{c}
@@ -166,6 +168,12 @@ func (c *Client) Logging() *LoggingResource {
 func (c *Client) PolicyFile() *PolicyFileResource {
 	c.init()
 	return c.policyFile
+}
+
+// Services provides access to https://tailscale.com/api#tag/services.
+func (c *Client) Services() *ServicesResource {
+	c.init()
+	return c.services
 }
 
 // TailnetSettings provides access to https://tailscale.com/api#tag/tailnetsettings.

--- a/services.go
+++ b/services.go
@@ -77,3 +77,68 @@ func (sr *ServicesResource) Delete(ctx context.Context, name string) error {
 
 	return sr.do(req, nil)
 }
+
+// ServiceDeviceApprovalStatus defines the approval level of a device that desires to serve a [Service].
+type ServiceDeviceApprovalStatus struct {
+	Approved     bool `json:"approved"`
+	AutoApproved bool `json:"autoApproved"`
+}
+
+// GetDeviceApprovalStatus returns the approval status indicating whether the given device may provide the given service.
+func (sr *ServicesResource) GetDeviceApprovalStatus(ctx context.Context, service string, device string) (*ServiceDeviceApprovalStatus, error) {
+	req, err := sr.buildRequest(ctx, http.MethodGet, sr.buildTailnetURL("services", service, "device", device))
+	if err != nil {
+		return nil, err
+	}
+
+	return body[ServiceDeviceApprovalStatus](sr, req)
+}
+
+type deviceApprovalStatusRequest struct {
+	Approved bool `json:"approved"`
+}
+
+// UpdateDeviceApprovalStatus sets whether a given device is approved to serve the given service.
+func (sr *ServicesResource) UpdateDeviceApprovalStatus(ctx context.Context, service string, device string, approved bool) (*ServiceDeviceApprovalStatus, error) {
+	req, err := sr.buildRequest(ctx, http.MethodPost, sr.buildTailnetURL("services", service, "device", device, "approved"), requestBody(deviceApprovalStatusRequest{Approved: approved}))
+	if err != nil {
+		return nil, err
+	}
+
+	return body[ServiceDeviceApprovalStatus](sr, req)
+}
+
+// ServiceDeviceApprovalLevel defines whether (and how) a tailnet device is allowed to serve a service.
+type ServiceDeviceApprovalLevel string
+
+const (
+	ServiceDeviceNotApproved      ServiceDeviceApprovalLevel = "not-approved"
+	ServiceDeviceAutoApproved     ServiceDeviceApprovalLevel = "approved:auto"
+	ServiceDeviceManuallyApproved ServiceDeviceApprovalLevel = "approved:manual"
+)
+
+// IsApproved returns true if and only if the device is approved for serving a service.
+func (dsal ServiceDeviceApprovalLevel) IsApproved() bool {
+	return dsal != ServiceDeviceNotApproved
+}
+
+// ServiceDeviceStatus indicates the status of a tailnet node that is serving a service.
+type ServiceDeviceStatus struct {
+	NodeID        string                     `json:"stableNodeID"`
+	ApprovalLevel ServiceDeviceApprovalLevel `json:"approvalLevel"`
+	Configured    string                     `json:"configured"`
+}
+
+// ListDevices returns a list of tailnet devices currently serving a service, with their approval status.
+func (sr *ServicesResource) ListDevices(ctx context.Context, service string) ([]ServiceDeviceStatus, error) {
+	req, err := sr.buildRequest(ctx, http.MethodGet, sr.buildTailnetURL("services", service, "devices"))
+	if err != nil {
+		return nil, err
+	}
+
+	resp := make(map[string][]ServiceDeviceStatus)
+	if err = sr.do(req, &resp); err != nil {
+		return nil, err
+	}
+	return resp["hosts"], nil
+}

--- a/services.go
+++ b/services.go
@@ -1,0 +1,79 @@
+// Copyright (c) David Bond, Tailscale Inc, & Contributors
+// SPDX-License-Identifier: MIT
+package tailscale
+
+import (
+	"context"
+	"net/http"
+)
+
+// ServicesResource provides access to https://tailscale.com/api#tag/services.
+type ServicesResource struct {
+	*Client
+}
+
+type Service struct {
+	Name    string   `json:"name"`
+	Addrs   []string `json:"addrs"`
+	Comment string   `json:"comment"`
+	Ports   []string `json:"ports"`
+	Tags    []string `json:"tags"`
+}
+
+type serviceUpdateOp func(Service) (svcName string, service Service)
+
+// WithServiceName is a functional option for [ServicesResource]'s Update method that allows specifying
+// the old name of the service that is to be renamed.
+func WithServiceName(name string) serviceUpdateOp {
+	return func(svc Service) (string, Service) {
+		return name, svc
+	}
+}
+
+// Update creates or updates a given [Service]. To rename a service, pass the [WithServiceName] option.
+func (sr *ServicesResource) Update(ctx context.Context, service Service, opts ...serviceUpdateOp) (*Service, error) {
+	name := service.Name
+	for _, opt := range opts {
+		name, service = opt(service)
+	}
+	req, err := sr.buildRequest(ctx, http.MethodPut, sr.buildTailnetURL("services", name), requestBody(service))
+	if err != nil {
+		return nil, err
+	}
+
+	return body[Service](sr, req)
+}
+
+// List lists every [Service] in the tailnet.
+func (sr *ServicesResource) List(ctx context.Context) ([]Service, error) {
+	u := sr.buildTailnetURL("services")
+	req, err := sr.buildRequest(ctx, http.MethodGet, u)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := make(map[string][]Service)
+	if err = sr.do(req, &resp); err != nil {
+		return nil, err
+	}
+	return resp["vipServices"], nil
+}
+
+// Get retrieves a specific [Service].
+func (sr *ServicesResource) Get(ctx context.Context, name string) (*Service, error) {
+	req, err := sr.buildRequest(ctx, http.MethodGet, sr.buildTailnetURL("services", name))
+	if err != nil {
+		return nil, err
+	}
+	return body[Service](sr, req)
+}
+
+// Delete deletes a specific service.
+func (sr *ServicesResource) Delete(ctx context.Context, name string) error {
+	req, err := sr.buildRequest(ctx, http.MethodDelete, sr.buildTailnetURL("services", name))
+	if err != nil {
+		return err
+	}
+
+	return sr.do(req, nil)
+}

--- a/services_test.go
+++ b/services_test.go
@@ -1,0 +1,111 @@
+// Copyright (c) David Bond, Tailscale Inc, & Contributors
+// SPDX-License-Identifier: MIT
+package tailscale
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClient_CreateService(t *testing.T) {
+	t.Parallel()
+	client, server := NewTestHarness(t)
+	server.ResponseCode = http.StatusOK
+
+	expected := &Service{
+		Name:    "testservice",
+		Comment: "a test comment",
+		Addrs:   []string{"127.0.0.1"},
+		Ports:   []string{"tcp:512"},
+		Tags:    []string{"tag:thisisatest"},
+	}
+	server.ResponseBody = expected
+	actual, err := client.Services().Update(context.Background(), *expected)
+	assert.NoError(t, err)
+	assert.EqualValues(t, expected, actual)
+	assert.Equal(t, http.MethodPut, server.Method)
+	assert.Equal(t, "/api/v2/tailnet/example.com/services/testservice", server.Path)
+
+	var actualReq Service
+	assert.NoError(t, json.Unmarshal(server.Body.Bytes(), &actualReq))
+	assert.EqualValues(t, "a test comment", actualReq.Comment)
+}
+
+func TestClient_RenameService(t *testing.T) {
+	t.Parallel()
+	client, server := NewTestHarness(t)
+	server.ResponseCode = http.StatusOK
+
+	expected := &Service{
+		Name:    "testservice2",
+		Comment: "a test comment",
+		Addrs:   []string{"127.0.0.1"},
+		Ports:   []string{"tcp:512"},
+		Tags:    []string{"tag:thisisatest"},
+	}
+	server.ResponseBody = expected
+	actual, err := client.Services().Update(context.Background(), *expected, WithServiceName("testservice"))
+	assert.NoError(t, err)
+	assert.EqualValues(t, expected, actual)
+	assert.Equal(t, http.MethodPut, server.Method)
+	assert.Equal(t, "/api/v2/tailnet/example.com/services/testservice", server.Path)
+
+	var actualReq Service
+	assert.NoError(t, json.Unmarshal(server.Body.Bytes(), &actualReq))
+	assert.EqualValues(t, "a test comment", actualReq.Comment)
+}
+
+func TestClient_GetService(t *testing.T) {
+	t.Parallel()
+	client, server := NewTestHarness(t)
+	server.ResponseCode = http.StatusOK
+
+	expected := &Service{
+		Name:    "testservice",
+		Comment: "a test comment",
+		Addrs:   []string{"127.0.0.1"},
+		Ports:   []string{"tcp:512"},
+		Tags:    []string{"tag:thisisatest"},
+	}
+	server.ResponseBody = expected
+	actual, err := client.Services().Get(context.Background(), expected.Name)
+	assert.NoError(t, err)
+	assert.EqualValues(t, expected, actual)
+	assert.Equal(t, http.MethodGet, server.Method)
+	assert.Equal(t, "/api/v2/tailnet/example.com/services/testservice", server.Path)
+}
+
+func TestClient_ListServices(t *testing.T) {
+	t.Parallel()
+	client, server := NewTestHarness(t)
+	server.ResponseCode = http.StatusOK
+
+	expected := []Service{
+		Service{
+			Name:    "testservice1",
+			Comment: "a test comment",
+			Addrs:   []string{"127.0.0.1"},
+			Ports:   []string{"tcp:512"},
+			Tags:    []string{"tag:thisisatest"},
+		},
+		Service{
+			Name:    "testservice2",
+			Comment: "another test comment",
+			Addrs:   []string{"127.0.0.2"},
+			Ports:   []string{"tcp:513"},
+			Tags:    []string{"tag:thisisatest2"},
+		},
+	}
+	server.ResponseBody = map[string][]Service{
+		"vipServices": expected,
+	}
+	actual, err := client.Services().List(context.Background())
+	assert.NoError(t, err)
+	assert.EqualValues(t, expected, actual)
+	assert.Equal(t, http.MethodGet, server.Method)
+	assert.Equal(t, "/api/v2/tailnet/example.com/services", server.Path)
+}


### PR DESCRIPTION
This PR introduces methods for creating, listing, retrieving and deleting [Services](https://tailscale.com/api#tag/services), including the device approval endpoints. This fixes #80.

## Idiosyncracies / stuff to address

- The `Update` method also creates services, [as the HTTP API does](https://tailscale.com/api#tag/services/put/tailnet/%7Btailnet%7D/services/%7BserviceName%7D), and uses a functional option to specify the "old name" if a service is to be renamed. I hope that's ok and not too clever.

Happy to address any feedback, my goal is to use these in the tailscale provider as soon as they land (: