### PR TITLE
vipservices: add VIP services support

### DIFF
--- a/client.go
+++ b/client.go
@@ -63,6 +63,7 @@ type Client struct {
 	policyFile      *PolicyFileResource
 	tailnetSettings *TailnetSettingsResource
 	users           *UsersResource
+	vipServices     *VIPServicesResource
 	webhooks        *WebhooksResource
 }
 
@@ -122,6 +123,7 @@ func (c *Client) init() {
 		c.policyFile = &PolicyFileResource{c}
 		c.tailnetSettings = &TailnetSettingsResource{c}
 		c.users = &UsersResource{c}
+		c.vipServices = &VIPServicesResource{c}
 		c.webhooks = &WebhooksResource{c}
 	})
 }
@@ -178,6 +180,12 @@ func (c *Client) TailnetSettings() *TailnetSettingsResource {
 func (c *Client) Users() *UsersResource {
 	c.init()
 	return c.users
+}
+
+// VIPServices provides access to https://tailscale.com/api#tag/vipservices.
+func (c *Client) VIPServices() *VIPServicesResource {
+	c.init()
+	return c.vipServices
 }
 
 // Webhooks provides access to https://tailscale.com/api#tag/webhooks.

--- a/vip_services.go
+++ b/vip_services.go
@@ -1,0 +1,72 @@
+// Copyright (c) David Bond, Tailscale Inc, & Contributors
+// SPDX-License-Identifier: MIT
+
+package tailscale
+
+import (
+	"context"
+	"net/http"
+)
+
+// VIPServicesResource provides access to https://tailscale.com/api#tag/vipservices.
+type VIPServicesResource struct {
+	*Client
+}
+
+// VIPService is a Tailscale VIP service with a stable virtual IP address.
+type VIPService struct {
+	Name        string            `json:"name,omitempty"`
+	Addrs       []string          `json:"addrs,omitempty"`
+	Comment     string            `json:"comment,omitempty"`
+	Annotations map[string]string `json:"annotations,omitempty"`
+	Ports       []string          `json:"ports,omitempty"`
+	Tags        []string          `json:"tags,omitempty"`
+}
+
+type vipServiceList struct {
+	VIPServices []VIPService `json:"vipServices"`
+}
+
+// List lists every [VIPService] in the tailnet.
+func (vr *VIPServicesResource) List(ctx context.Context) ([]VIPService, error) {
+	req, err := vr.buildRequest(ctx, http.MethodGet, vr.buildTailnetURL("vip-services"))
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := body[vipServiceList](vr, req)
+	if err != nil {
+		return nil, err
+	}
+	return resp.VIPServices, nil
+}
+
+// Get retrieves a specific [VIPService] by name.
+func (vr *VIPServicesResource) Get(ctx context.Context, name string) (*VIPService, error) {
+	req, err := vr.buildRequest(ctx, http.MethodGet, vr.buildTailnetURL("vip-services", name))
+	if err != nil {
+		return nil, err
+	}
+
+	return body[VIPService](vr, req)
+}
+
+// CreateOrUpdate creates or updates a [VIPService].
+func (vr *VIPServicesResource) CreateOrUpdate(ctx context.Context, svc VIPService) error {
+	req, err := vr.buildRequest(ctx, http.MethodPut, vr.buildTailnetURL("vip-services", svc.Name), requestBody(svc))
+	if err != nil {
+		return err
+	}
+
+	return vr.do(req, nil)
+}
+
+// Delete deletes a specific [VIPService].
+func (vr *VIPServicesResource) Delete(ctx context.Context, name string) error {
+	req, err := vr.buildRequest(ctx, http.MethodDelete, vr.buildTailnetURL("vip-services", name))
+	if err != nil {
+		return err
+	}
+
+	return vr.do(req, nil)
+}

--- a/vip_services_test.go
+++ b/vip_services_test.go
@@ -1,0 +1,107 @@
+// Copyright (c) David Bond, Tailscale Inc, & Contributors
+// SPDX-License-Identifier: MIT
+
+package tailscale
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClient_ListVIPServices(t *testing.T) {
+	t.Parallel()
+
+	client, server := NewTestHarness(t)
+	server.ResponseCode = http.StatusOK
+
+	expected := []VIPService{
+		{
+			Name:    "svc:my-service",
+			Addrs:   []string{"100.64.0.1", "fd7a:115c:a1e0::1"},
+			Comment: "test service",
+			Ports:   []string{"443"},
+			Tags:    []string{"tag:web"},
+		},
+	}
+	server.ResponseBody = vipServiceList{VIPServices: expected}
+
+	actual, err := client.VIPServices().List(context.Background())
+	assert.NoError(t, err)
+	assert.Equal(t, http.MethodGet, server.Method)
+	assert.Equal(t, "/api/v2/tailnet/example.com/vip-services", server.Path)
+	assert.Equal(t, expected, actual)
+}
+
+func TestClient_GetVIPService(t *testing.T) {
+	t.Parallel()
+
+	client, server := NewTestHarness(t)
+	server.ResponseCode = http.StatusOK
+
+	expected := &VIPService{
+		Name:    "svc:my-service",
+		Addrs:   []string{"100.64.0.1", "fd7a:115c:a1e0::1"},
+		Comment: "test service",
+		Ports:   []string{"443"},
+		Tags:    []string{"tag:web"},
+	}
+	server.ResponseBody = expected
+
+	actual, err := client.VIPServices().Get(context.Background(), "svc:my-service")
+	assert.NoError(t, err)
+	assert.Equal(t, http.MethodGet, server.Method)
+	assert.Equal(t, "/api/v2/tailnet/example.com/vip-services/svc:my-service", server.Path)
+	assert.Equal(t, expected, actual)
+}
+
+func TestClient_CreateOrUpdateVIPService(t *testing.T) {
+	t.Parallel()
+
+	client, server := NewTestHarness(t)
+	server.ResponseCode = http.StatusOK
+
+	svc := VIPService{
+		Name:    "svc:my-service",
+		Comment: "new service",
+		Ports:   []string{"443"},
+		Tags:    []string{"tag:web"},
+	}
+
+	err := client.VIPServices().CreateOrUpdate(context.Background(), svc)
+	assert.NoError(t, err)
+	assert.Equal(t, http.MethodPut, server.Method)
+	assert.Equal(t, "/api/v2/tailnet/example.com/vip-services/svc:my-service", server.Path)
+
+	var received VIPService
+	err = json.Unmarshal(server.Body.Bytes(), &received)
+	assert.NoError(t, err)
+	assert.Equal(t, svc, received)
+}
+
+func TestClient_DeleteVIPService(t *testing.T) {
+	t.Parallel()
+
+	client, server := NewTestHarness(t)
+	server.ResponseCode = http.StatusOK
+
+	err := client.VIPServices().Delete(context.Background(), "svc:my-service")
+	assert.NoError(t, err)
+	assert.Equal(t, http.MethodDelete, server.Method)
+	assert.Equal(t, "/api/v2/tailnet/example.com/vip-services/svc:my-service", server.Path)
+}
+
+func TestClient_GetVIPService_NotFound(t *testing.T) {
+	t.Parallel()
+
+	client, server := NewTestHarness(t)
+	server.ResponseCode = http.StatusNotFound
+	server.ResponseBody = APIError{Message: "not found"}
+
+	_, err := client.VIPServices().Get(context.Background(), "svc:nonexistent")
+	assert.Error(t, err)
+	assert.True(t, IsNotFound(err))
+}


### PR DESCRIPTION
Add client support for the VIP services API (`/api/v2/tailnet/{tailnet}/vip-services`).

- List, Get, CreateOrUpdate, Delete
- Tested against live API

Fixes #80