### PR TITLE
policyfile: add PresetAppID field to NodeAttrGrantApp

### DIFF
--- a/policyfile.go
+++ b/policyfile.go
@@ -161,9 +161,10 @@ type NodeAttrGrant struct {
 }
 
 type NodeAttrGrantApp struct {
-	Name       string   `json:"name,omitempty" hujson:"Name,omitempty"`
-	Connectors []string `json:"connectors,omitempty" hujson:"Connectors,omitempty"`
-	Domains    []string `json:"domains,omitempty" hujson:"Domains,omitempty"`
+	Name        string   `json:"name,omitempty" hujson:"Name,omitempty"`
+	Connectors  []string `json:"connectors,omitempty" hujson:"Connectors,omitempty"`
+	Domains     []string `json:"domains,omitempty" hujson:"Domains,omitempty"`
+	PresetAppID string   `json:"presetAppID,omitempty" hujson:"PresetAppID,omitempty"`
 }
 
 type Grant struct {


### PR DESCRIPTION
## Summary

- Adds the missing `PresetAppID` field to `NodeAttrGrantApp`, enabling clients to configure preset app connectors (e.g. GitHub, Okta, Salesforce) via the structured ACL types.

The `presetAppID` JSON key is documented in the [Tailscale app connector docs](https://tailscale.com/kb/1342/app-connector-config#edit-preset-apps) and is used when Tailscale automatically manages domains and routes for supported SaaS applications.

### Example usage in a tailnet policy file

```json
"nodeAttrs": [
  {
    "target": ["*"],
    "app": {
      "tailscale.com/app-connectors": [
        {
          "name": "github app",
          "connectors": ["tag:code"],
          "presetAppID": "github"
        }
      ]
    }
  }
]
```