### PR TITLE
policyfile: handle 200 OK responses; support ACL tests; add tests

### DIFF
--- a/client.go
+++ b/client.go
@@ -330,15 +330,20 @@ func (c *Client) do(req *http.Request, out any) error {
 }
 
 func (c *Client) doWithResponseHeaders(req *http.Request, out any) (http.Header, error) {
+	_, header, err := c.doWithStatusAndResponseHeaders(req, out)
+	return header, err
+}
+
+func (c *Client) doWithStatusAndResponseHeaders(req *http.Request, out any) (int, http.Header, error) {
 	res, err := c.HTTP.Do(req)
 	if err != nil {
-		return nil, err
+		return res.StatusCode, nil, err
 	}
 	defer res.Body.Close()
 
 	body, err := io.ReadAll(res.Body)
 	if err != nil {
-		return nil, err
+		return res.StatusCode, nil, err
 	}
 
 	if res.StatusCode >= http.StatusOK && res.StatusCode < http.StatusMultipleChoices {
@@ -346,37 +351,37 @@ func (c *Client) doWithResponseHeaders(req *http.Request, out any) (http.Header,
 		// API responses have empty bodies, so we don't want to try and standardize them for
 		// parsing.
 		if out == nil {
-			return res.Header, nil
+			return res.StatusCode, res.Header, nil
 		}
 
 		// If we're expected to write result into a []byte, do not attempt to parse it.
 		if o, ok := out.(*[]byte); ok {
 			*o = bytes.Clone(body)
-			return res.Header, nil
+			return res.StatusCode, res.Header, nil
 		}
 
 		// If we've got hujson back, convert it to JSON, so we can natively parse it.
 		if !json.Valid(body) {
 			body, err = hujson.Standardize(body)
 			if err != nil {
-				return res.Header, err
+				return res.StatusCode, res.Header, err
 			}
 		}
 
-		return res.Header, json.Unmarshal(body, out)
+		return res.StatusCode, res.Header, json.Unmarshal(body, out)
 	}
 
 	if res.StatusCode >= http.StatusBadRequest {
 		var apiErr APIError
 		if err := json.Unmarshal(body, &apiErr); err != nil {
-			return res.Header, err
+			return res.StatusCode, res.Header, err
 		}
 
 		apiErr.Status = res.StatusCode
-		return res.Header, apiErr
+		return res.StatusCode, res.Header, apiErr
 	}
 
-	return res.Header, nil
+	return res.StatusCode, res.Header, nil
 }
 
 func (err APIError) Error() string {

--- a/policyfile.go
+++ b/policyfile.go
@@ -5,6 +5,7 @@ package tailscale
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
@@ -274,17 +275,19 @@ func (pr *PolicyFileResource) SetAndGet(ctx context.Context, acl ACL, etag strin
 	return out, nil
 }
 
-// Validate validates the provided ACL via the API. acl can either be an [ACL], or a HuJSON string.
+// Validate validates the provided ACL via the API. acl can either be an [ACL], a list of [ACLTest],
+// or a HuJSON string.
 func (pr *PolicyFileResource) Validate(ctx context.Context, acl any) error {
 	reqOpts := []requestOption{
 		requestBody(acl),
 	}
 	switch v := acl.(type) {
 	case ACL:
+	case []ACLTest:
 	case string:
 		reqOpts = append(reqOpts, requestContentType("application/hujson"))
 	default:
-		return fmt.Errorf("expected ACL content as a string or as ACL struct; got %T", v)
+		return fmt.Errorf("expected ACL content as a string, an ACL struct, or a list of ACLTest; got %T", v)
 	}
 
 	req, err := pr.buildRequest(ctx, http.MethodPost, pr.buildTailnetURL("acl", "validate"), reqOpts...)
@@ -292,12 +295,24 @@ func (pr *PolicyFileResource) Validate(ctx context.Context, acl any) error {
 		return err
 	}
 
-	var response APIError
-	if err := pr.do(req, &response); err != nil {
+	var body []byte
+	statusCode, _, err := pr.doWithStatusAndResponseHeaders(req, &body)
+	if err != nil {
 		return err
 	}
-	if response.Message != "" {
-		return fmt.Errorf("ACL validation failed: %s; %v", response.Message, response.Data)
+
+	// The API returns a 200 OK with an empty response body if the tests passed.
+	if statusCode == http.StatusOK && len(body) == 0 {
+		return nil
+	}
+
+	// If we got a non-200 OK or a non-empty response body, parse it as an APIError.
+	var apiErr APIError
+	if err := json.Unmarshal(body, &apiErr); err != nil {
+		return fmt.Errorf("unable to unmarshal JSON response: %v", err)
+	}
+	if apiErr.Message != "" {
+		return fmt.Errorf("ACL validation failed: %s; %v", apiErr.Message, apiErr.Data)
 	}
 	return nil
 }

--- a/policyfile_test.go
+++ b/policyfile_test.go
@@ -630,3 +630,96 @@ func TestSSHCheckPeriod(t *testing.T) {
 		})
 	}
 }
+
+func TestClient_ValidateACL(t *testing.T) {
+	t.Parallel()
+
+	t.Run("passing-test", func(t *testing.T) {
+		client, server := NewTestHarness(t)
+		server.ResponseCode = http.StatusOK
+		server.ResponseBody = nil
+
+		err := client.PolicyFile().Validate(t.Context(), `
+			'[
+				{
+				"src": "user1@example.com",
+				"accept": [
+					"example-host-1:22"
+				],
+				"deny": [
+					"example-host-2:100"
+				]
+				}
+			]'
+		`)
+		assert.NoError(t, err)
+	})
+
+	t.Run("passing-test-as-acl", func(t *testing.T) {
+		client, server := NewTestHarness(t)
+		server.ResponseCode = http.StatusOK
+
+		err := client.PolicyFile().Validate(t.Context(), ACL{
+			Grants: []Grant{},
+		})
+		assert.NoError(t, err)
+	})
+
+	t.Run("failing-test-as-string-literal", func(t *testing.T) {
+		client, server := NewTestHarness(t)
+		server.ResponseCode = http.StatusOK
+		body := []byte(`{
+			"message": "test(s) failed",
+			"data": [
+				{
+					"user": "user1@example.com",
+					"errors": [
+						"[acl test error]: user or host is invalid: unknown user or host: \"example-host-1\""
+					]
+				}
+			]
+		}`)
+		server.ResponseBody = body
+
+		err := client.PolicyFile().Validate(t.Context(), `
+			'[
+				{
+				"src": "user1@example.com",
+				"accept": [
+					"example-host-1:22"
+				],
+				"deny": [
+					"example-host-2:100"
+				]
+				}
+			]'
+		`)
+		assert.EqualValues(t, err.Error(), "ACL validation failed: test(s) failed; [{user1@example.com [[acl test error]: user or host is invalid: unknown user or host: \"example-host-1\"]}]")
+	})
+
+	t.Run("failing-list-of-acl-tests", func(t *testing.T) {
+		client, server := NewTestHarness(t)
+		server.ResponseCode = http.StatusOK
+		body := []byte(`{
+			"message": "test(s) failed",
+			"data": [
+				{
+					"user": "user1@example.com",
+					"errors": [
+						"[acl test error]: user or host is invalid: unknown user or host: \"example-host-1\""
+					]
+				}
+			]
+		}`)
+		server.ResponseBody = body
+
+		err := client.PolicyFile().Validate(t.Context(), []ACLTest{
+			{
+				User:  "user1@example.com",
+				Allow: []string{"example-host-1:22"},
+				Deny:  []string{"example-host-2:100"},
+			},
+		})
+		assert.EqualValues(t, err.Error(), "ACL validation failed: test(s) failed; [{user1@example.com [[acl test error]: user or host is invalid: unknown user or host: \"example-host-1\"]}]")
+	})
+}


### PR DESCRIPTION
* The `/validate` endpoint returns a 200 OK with an empty response if the tests pass. Ensure the `Validate()` method handles this correctly; previously it tried to parse all responses as an `APIError`, which caused EOF errors for successful tests.

* The `/validate` endpoint takes a complete ACL or a list of ACL tests. Ensure the `Validate()` method handles this correctly; previously it would reject the slice as an unrecognised type.

* Add missing tests for the `Validate()` method.

Fixes #100