### PR TITLE
fix: prevent nil pointer dereference in doWithStatusAndResponseHeaders on HTTP error

### DIFF
--- a/client.go
+++ b/client.go
@@ -337,7 +337,7 @@ func (c *Client) doWithResponseHeaders(req *http.Request, out any) (http.Header,
 func (c *Client) doWithStatusAndResponseHeaders(req *http.Request, out any) (int, http.Header, error) {
 	res, err := c.HTTP.Do(req)
 	if err != nil {
-		return res.StatusCode, nil, err
+		return 0, nil, err
 	}
 	defer res.Body.Close()
 


### PR DESCRIPTION
## Description

Fixes a nil pointer dereference panic in `doWithStatusAndResponseHeaders` when `c.HTTP.Do(req)` returns an error.

## The Bug

In `client.go:340`, when `c.HTTP.Do(req)` returns a non-nil error, Go's `http.Client.Do` contract allows `res` to be nil. The code accesses `res.StatusCode` without checking for nil first, causing a panic:

```go
func (c *Client) doWithStatusAndResponseHeaders(req *http.Request, out any) (int, http.Header, error) {
	res, err := c.HTTP.Do(req)
	if err != nil {
		return res.StatusCode, nil, err   // panics when res is nil
	}
```

## The Fix

Return `0` as the status code on error instead of `res.StatusCode`:

```go
func (c *Client) doWithStatusAndResponseHeaders(req *http.Request, out any) (int, http.Header, error) {
	res, err := c.HTTP.Do(req)
	if err != nil {
		return 0, nil, err
	}
```

## Impact

- Any transient network error (DNS failure, connection refused, TLS error, OAuth token exchange timeout) crashes the entire Go process
- Affects all API operations since they all route through this function
- Users of the `Auth` field (OAuth client credentials) are particularly exposed because the token exchange involves an additional HTTP request

## Related

This is the same principle applied in commit `521047c` by Brad Fitzpatrick for the simpler `do()` method — return zero values on error.

Fixes #104
