### PR TITLE
tailnet: add support for the tailnet API endpoints

### DIFF
--- a/client.go
+++ b/client.go
@@ -61,6 +61,7 @@ type Client struct {
 	keys            *KeysResource
 	logging         *LoggingResource
 	policyFile      *PolicyFileResource
+	tailnets        *TailnetsResource
 	tailnetSettings *TailnetSettingsResource
 	users           *UsersResource
 	services        *ServicesResource
@@ -121,6 +122,7 @@ func (c *Client) init() {
 		c.keys = &KeysResource{c}
 		c.logging = &LoggingResource{c}
 		c.policyFile = &PolicyFileResource{c}
+		c.tailnets = &TailnetsResource{c}
 		c.tailnetSettings = &TailnetSettingsResource{c}
 		c.users = &UsersResource{c}
 		c.services = &ServicesResource{c}
@@ -168,6 +170,12 @@ func (c *Client) Logging() *LoggingResource {
 func (c *Client) PolicyFile() *PolicyFileResource {
 	c.init()
 	return c.policyFile
+}
+
+// Tailnets provides access to tailnet creation APIs.
+func (c *Client) Tailnets() *TailnetsResource {
+	c.init()
+	return c.tailnets
 }
 
 // TailnetSettings provides access to https://tailscale.com/api#tag/tailnetsettings.

--- a/tailnet.go
+++ b/tailnet.go
@@ -1,0 +1,71 @@
+// Copyright (c) David Bond, Tailscale Inc, & Contributors
+// SPDX-License-Identifier: MIT
+
+package tailscale
+
+import (
+	"context"
+	"net/http"
+	"time"
+)
+
+// TailnetsResource provides access to tailnet creation APIs.
+type TailnetsResource struct {
+	*Client
+}
+
+// CreateTailnetRequest describes the definition of an API-only tailnet to create.
+type CreateTailnetRequest struct {
+	DisplayName string `json:"displayName"`
+}
+
+// Tailnet describes a tailnet in an organization.
+type Tailnet struct {
+	ID          string              `json:"id"`
+	DisplayName string              `json:"displayName"`
+	OrgID       string              `json:"orgId"`
+	DNSName     string              `json:"dnsName"`
+	CreatedAt   time.Time           `json:"createdAt"`
+	OAuthClient *TailnetOAuthClient `json:"oauthClient,omitempty"`
+}
+
+// TailnetOAuthClient describes the OAuth client returned when creating an API-only tailnet.
+type TailnetOAuthClient struct {
+	ID     string `json:"id"`
+	Secret string `json:"secret"`
+}
+
+// Create creates a new API-only tailnet. Returns the created [Tailnet] if successful.
+func (tr *TailnetsResource) Create(ctx context.Context, request CreateTailnetRequest) (*Tailnet, error) {
+	req, err := tr.buildRequest(ctx, http.MethodPost, tr.buildURL("organizations", "-", "tailnets"), requestBody(request))
+	if err != nil {
+		return nil, err
+	}
+
+	return body[Tailnet](tr, req)
+}
+
+// List lists every tailnet in the organization.
+func (tr *TailnetsResource) List(ctx context.Context) ([]Tailnet, error) {
+	req, err := tr.buildRequest(ctx, http.MethodGet, tr.buildURL("organizations", "-", "tailnets"))
+	if err != nil {
+		return nil, err
+	}
+
+	resp := make(map[string][]Tailnet)
+	if err = tr.do(req, &resp); err != nil {
+		return nil, err
+	}
+
+	return resp["tailnets"], nil
+}
+
+// Delete deletes the tailnet identified by the client's configured tailnet.
+func (tr *TailnetsResource) Delete(ctx context.Context) error {
+	req, err := tr.buildRequest(ctx, http.MethodDelete, tr.buildTailnetURL())
+	if err != nil {
+		return err
+	}
+
+	return tr.do(req, nil)
+}

--- a/tailnet.go
+++ b/tailnet.go
@@ -60,7 +60,7 @@ func (tr *TailnetsResource) List(ctx context.Context) ([]Tailnet, error) {
 	return resp["tailnets"], nil
 }
 
-// Delete deletes the tailnet identified by the client's configured tailnet.
+// Delete deletes the tailnet associated with the current client.
 func (tr *TailnetsResource) Delete(ctx context.Context) error {
 	req, err := tr.buildRequest(ctx, http.MethodDelete, tr.buildTailnetURL())
 	if err != nil {

--- a/tailnet_test.go
+++ b/tailnet_test.go
@@ -1,0 +1,92 @@
+// Copyright (c) David Bond, Tailscale Inc, & Contributors
+// SPDX-License-Identifier: MIT
+
+package tailscale
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClient_Tailnets_Create(t *testing.T) {
+	t.Parallel()
+
+	client, server := NewTestHarness(t)
+	server.ResponseCode = http.StatusOK
+
+	createRequest := CreateTailnetRequest{
+		DisplayName: "Example Tailnet",
+	}
+	expected := &Tailnet{
+		ID:          "T123456CNTRL",
+		DisplayName: createRequest.DisplayName,
+		OrgID:       "o123456CNTRL",
+		DNSName:     "tail1234.ts.net",
+		CreatedAt:   time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC),
+		OAuthClient: &TailnetOAuthClient{
+			ID:     "k123456CNTRL",
+			Secret: "tskey-client-xxxxxxxxxxxx-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+		},
+	}
+	server.ResponseBody = expected
+
+	actual, err := client.Tailnets().Create(context.Background(), createRequest)
+	assert.NoError(t, err)
+	assert.Equal(t, http.MethodPost, server.Method)
+	assert.Equal(t, "/api/v2/organizations/-/tailnets", server.Path)
+	assert.Equal(t, expected, actual)
+	assert.Equal(t, expected.OAuthClient.Secret, actual.OAuthClient.Secret)
+
+	var receivedRequest CreateTailnetRequest
+	err = json.Unmarshal(server.Body.Bytes(), &receivedRequest)
+	assert.NoError(t, err)
+	assert.Equal(t, createRequest, receivedRequest)
+}
+
+func TestClient_Tailnets_List(t *testing.T) {
+	t.Parallel()
+
+	client, server := NewTestHarness(t)
+	server.ResponseCode = http.StatusOK
+
+	expectedTailnets := map[string][]Tailnet{
+		"tailnets": {
+			{
+				ID:          "T123456CNTRL",
+				DisplayName: "Example Tailnet",
+				OrgID:       "o123456CNTRL",
+				CreatedAt:   time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC),
+			},
+			{
+				ID:          "T654321CNTRL",
+				DisplayName: "Another Tailnet",
+				OrgID:       "o123456CNTRL",
+				CreatedAt:   time.Date(2025, 1, 2, 12, 0, 0, 0, time.UTC),
+			},
+		},
+	}
+	server.ResponseBody = expectedTailnets
+
+	actual, err := client.Tailnets().List(context.Background())
+	assert.NoError(t, err)
+	assert.Equal(t, http.MethodGet, server.Method)
+	assert.Equal(t, "/api/v2/organizations/-/tailnets", server.Path)
+	assert.Equal(t, expectedTailnets["tailnets"], actual)
+}
+
+func TestClient_Tailnets_Delete(t *testing.T) {
+	t.Parallel()
+
+	client, server := NewTestHarness(t)
+	server.ResponseCode = http.StatusOK
+
+	err := client.Tailnets().Delete(context.Background())
+	assert.NoError(t, err)
+	assert.Equal(t, http.MethodDelete, server.Method)
+	assert.Equal(t, "/api/v2/tailnet/example.com", server.Path)
+}


### PR DESCRIPTION
Note: this change does not add support for the oauth exchange, will need to be handled by the user